### PR TITLE
Filter fields

### DIFF
--- a/bird/config.go
+++ b/bird/config.go
@@ -15,6 +15,10 @@ type BirdConfig struct {
 	BirdCmd        string `toml:"birdc"`
 }
 
+type ParserConfig struct {
+	FilterFields []string `toml:"filter_fields"`
+}
+
 type RateLimitConfig struct {
 	Reqs    int
 	Max     int `toml:"requests_per_minute"`

--- a/bird/parser.go
+++ b/bird/parser.go
@@ -6,7 +6,18 @@ import (
 	"strings"
 )
 
+var ParserConf ParserConfig
+
 type Parsed map[string]interface{}
+
+func dirtyContains(l []string, e string) bool {
+	for _, c := range l {
+		if c == e {
+			return true
+		}
+	}
+	return false
+}
 
 func emptyLine(line string) bool {
 	return len(strings.TrimSpace(line)) == 0
@@ -117,6 +128,13 @@ func mainRouteDetail(groups []string, route Parsed) Parsed {
 	route["learnt_from"] = groups[6]
 	route["primary"] = groups[7] == "*"
 	route["metric"] = parseInt(groups[8])
+
+	for k, _ := range route {
+		if !dirtyContains(ParserConf.FilterFields, k) {
+			route[k] = nil
+		}
+	}
+
 	return route
 }
 

--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -125,6 +125,7 @@ func main() {
 	bird.ClientConf = birdConf
 	bird.StatusConf = conf.Status
 	bird.RateLimitConf.Conf = conf.Ratelimit
+	bird.ParserConf = conf.Parser
 	endpoints.Conf = conf.Server
 
 	// Make server

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Status    bird.StatusConfig
 	Bird      bird.BirdConfig
 	Bird6     bird.BirdConfig
+	Parser    bird.ParserConfig
 }
 
 // Try to load configfiles as specified in the files

--- a/etc/ecix/birdwatcher.conf
+++ b/etc/ecix/birdwatcher.conf
@@ -50,4 +50,6 @@ listen = "0.0.0.0:29189"
 config = "/etc/bird6.conf"
 birdc  = "birdc6"
 
-
+[parser]
+# Remove fields e.g. interface
+filter_fields = []


### PR DESCRIPTION
This PR introduces a new config section called `parser` that is responsible for configuring the parser (duh!). For now it is only used to filter fields within the route parser, but if/when the need arises to toggle more options in the parser, this is what we should extend.

It also implements the field filtering. For now this only applies to general route information (`interface`, `gatreway`, `learnt_from`, and such), but again, this can be extended if needed.

Cheers

PS: I just accidently opened this PR to the original repo. Always check your upstreams.