### PR TITLE
Added -config argument for custom config files

### DIFF
--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -98,16 +98,13 @@ func PrintServiceInfo(conf *Config, birdConf bird.BirdConfig) {
 
 func main() {
 	bird6 := flag.Bool("6", false, "Use bird6 instead of bird")
+	configfile := flag.String("config", "./etc/ecix/birdwatcher.conf", "Configuration file location")
 	flag.Parse()
 
 	endpoints.VERSION = VERSION
 	bird.InstallRateLimitReset()
 	// Load configurations
-	conf, err := LoadConfigs([]string{
-		"./etc/ecix/birdwatcher.conf",
-		"/etc/ecix/birdwatcher.conf",
-		"./etc/ecix/birdwatcher.local.conf",
-	})
+	conf, err := LoadConfigs(ConfigOptions(*configfile))
 
 	if err != nil {
 		log.Fatal("Loading birdwatcher configuration failed:", err)

--- a/config.go
+++ b/config.go
@@ -59,7 +59,7 @@ func LoadConfigs(configFiles []string) (*Config, error) {
 func ConfigOptions(filename string) []string {
 	return []string{
 		strings.Join([]string{"/", filename}, ""),
-		filename,
+		strings.Join([]string{"./", filename}, ""),
 		strings.Replace(filename, ".conf", ".local.conf", 1),
 	}
 }

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/imdario/mergo"
@@ -53,4 +54,12 @@ func LoadConfigs(configFiles []string) (*Config, error) {
 	}
 
 	return config, confError
+}
+
+func ConfigOptions(filename string) []string {
+	return []string{
+		strings.Join([]string{"/", filename}, ""),
+		filename,
+		strings.Replace(filename, ".conf", ".local.conf", 1),
+	}
 }


### PR DESCRIPTION
This PR enables us to use custom configuration file locations as per suggestion by @job in #5.

The code is a little shady, but it works. If there is a better (yet simple) way to achieve what I do [here](https://github.com/ecix/birdwatcher/blob/custom_conf/config.go#L59), I will gladly take your suggestions.

Cheers