### PR TITLE
Optimized performance when using big routing tables / full tables

### DIFF
--- a/bird/bird.go
+++ b/bird/bird.go
@@ -200,7 +200,7 @@ func RoutesProtoCount(protocol string) (Parsed, bool) {
 }
 
 func RoutesFiltered(protocol string) (Parsed, bool) {
-	cmd := routeQueryForChannel("route all filtered " + protocol)
+	cmd := routeQueryForChannel("route all filtered protocol " + protocol)
 	return RunAndParse(cmd, parseRoutes)
 }
 

--- a/bird/parser.go
+++ b/bird/parser.go
@@ -9,7 +9,8 @@ import (
 	"sync"
 )
 
-const workerPoolSize = 8
+// WorkerPoolSize is the number of go routines used to parse routing tables concurrently
+var WorkerPoolSize = 8
 
 var (
 	ParserConf ParserConfig
@@ -225,9 +226,9 @@ func startRouteWorkers(jobs chan blockJob) chan blockParsed {
 	out := make(chan blockParsed)
 
 	wg := &sync.WaitGroup{}
-	wg.Add(workerPoolSize)
+	wg.Add(WorkerPoolSize)
 	go func() {
-		for i := 0; i < workerPoolSize; i++ {
+		for i := 0; i < WorkerPoolSize; i++ {
 			go workerForRouteBlockParsing(jobs, out, wg)
 		}
 		wg.Wait()

--- a/birdwatcher.go
+++ b/birdwatcher.go
@@ -107,8 +107,11 @@ func PrintServiceInfo(conf *Config, birdConf bird.BirdConfig) {
 
 func main() {
 	bird6 := flag.Bool("6", false, "Use bird6 instead of bird")
+	workerPoolSize := flag.Int("worker-pool-size", 8, "Number of go routines used to parse routing tables concurrently")
 	configfile := flag.String("config", "./etc/ecix/birdwatcher.conf", "Configuration file location")
 	flag.Parse()
+
+	bird.WorkerPoolSize = *workerPoolSize
 
 	endpoints.VERSION = VERSION
 	bird.InstallRateLimitReset()


### PR DESCRIPTION
* removed unused regex
* improved parsing performance of big routing tables by parsing blocks in worker go routines

In my test scenario parsing of an IPv6 full table took 5-6 secs before optimization. Now it's around 2 secs. I ensured a deterministic result by sorting the map items after parsing. This of course costs a litte performance.