### PR TITLE
parser.go: Fix Bird 2.0 BGP protocol parsing

### DIFF
--- a/bird/parser.go
+++ b/bird/parser.go
@@ -64,7 +64,7 @@ func init() {
 	regex.routeCount.countRx = regexp.MustCompile(`^(\d+)\s+of\s+(\d+)\s+routes.*$`)
 
 	regex.bgp.channel = regexp.MustCompile("Channel ipv([46])")
-	regex.bgp.protocol = regexp.MustCompile(`^([\w\.:]+)\s+BGP\s+(\w+)\s+(\w+)\s+([0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s*(\w+)?.*$`)
+	regex.bgp.protocol = regexp.MustCompile(`^([\w\.:]+)\s+BGP\s+(\w+|\-\-\-)\s+(\w+)\s+([0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2})\s*(\w+)?.*$`)
 	regex.bgp.numericValue = regexp.MustCompile(`^\s+([^:]+):\s+([\d]+)\s*$`)
 	regex.bgp.routes = regexp.MustCompile(`^\s+Routes:\s+(.*)`)
 	regex.bgp.stringValue = regexp.MustCompile(`^\s+([^:]+):\s+(.+)\s*$`)
@@ -532,6 +532,11 @@ func parseBgpStringValuesRx(line string, res Parsed) bool {
 	}
 
 	key := treatKey(groups[1])
+	if key == "state" {
+		// Don't parse the state of Bird 2.x channels for now
+		return false
+	}
+
 	res[key] = groups[2]
 	return true
 }


### PR DESCRIPTION
In Bird 2.0, BGP protocol lines have `---` as the table name, as the actual table names are defined in the respective channels. This commit fixes the regex to take this into account.

Parsing of the key-value section is also changed so that we don't mistake the states of individual channels as the protocol state. In the future, we should distinguish between different channels instead of parsing the key-value section blindly.

Example:

```
xxx1_4     BGP        ---        up     2018-08-21 08:44:30  Established
  Description:    iBGP xxx1 v4
  BGP state:          Established
  <snip>
  Channel ipv4
    State:          UP
    Table:          master4
  <snip>
```
---
- Expected `state`: `up`
- Parsed `state`: `UP` (from the ipv4 channel)
---
- Expected `state_changed`: `2018-08-21 08:44:30`
- Parsed `state_changed`: Not parsed